### PR TITLE
fix wrong labels which cause service monitor exception

### DIFF
--- a/api/v1/mongodbcommunity_types.go
+++ b/api/v1/mongodbcommunity_types.go
@@ -844,6 +844,21 @@ func (m MongoDBCommunity) NeedsAutomationConfigVolume() bool {
 	return true
 }
 
+func (m MongoDBCommunity) BuildLabel(isArbiter bool) map[string]string {
+	name := m.ServiceName()
+	if isArbiter {
+		name = m.ArbiterServiceName()
+	}
+
+	labels := make(map[string]string)
+	labels["app.kubernetes.io/name"] = "mongodb"
+	labels["app.kubernetes.io/component"] = "database"
+	labels["app.kubernetes.io/instance"] = m.Name
+	labels["mongodbcommunity.mongodb.com/app"] = name
+
+	return labels
+}
+
 type automationConfigReplicasScaler struct {
 	current, desired       int
 	forceIndividualScaling bool

--- a/controllers/construct/mongodbstatefulset.go
+++ b/controllers/construct/mongodbstatefulset.go
@@ -90,15 +90,16 @@ type MongoDBStatefulSetOwner interface {
 
 	// NeedsAutomationConfigVolume returns whether the statefuslet needs to have a volume for the automationconfig.
 	NeedsAutomationConfigVolume() bool
+
+	// BuildLabel return the labels which will set into the statefulset/service of mongodb cluster
+	BuildLabel(isArbiter bool) map[string]string
 }
 
 // BuildMongoDBReplicaSetStatefulSetModificationFunction builds the parts of the replica set that are common between every resource that implements
 // MongoDBStatefulSetOwner.
 // It doesn't configure TLS or additional containers/env vars that the statefulset might need.
 func BuildMongoDBReplicaSetStatefulSetModificationFunction(mdb MongoDBStatefulSetOwner, scaler scale.ReplicaSetScaler) statefulset.Modification {
-	labels := map[string]string{
-		"app": mdb.ServiceName(),
-	}
+	labels := mdb.BuildLabel(false)
 
 	// the health status volume is required in both agent and mongod pods.
 	// the mongod requires it to determine if an upgrade is happening and needs to kill the pod

--- a/controllers/replica_set_controller.go
+++ b/controllers/replica_set_controller.go
@@ -702,21 +702,18 @@ func buildAutomationConfig(mdb mdbv1.MongoDBCommunity, auth automationconfig.Aut
 // If `isArbiter` is true, the function will create a Service suitable for the
 // Arbiter's StatefulSet.
 func buildService(mdb mdbv1.MongoDBCommunity, isArbiter bool) corev1.Service {
-	label := make(map[string]string)
-
 	name := mdb.ServiceName()
 	if isArbiter {
 		name = mdb.ArbiterServiceName()
 	}
 
-	label["app.kubernetes.io/name"] = "mongodb"
-	label["app.kubernetes.io/component"] = "database"
-	label["app.kubernetes.io/instance"] = "radondb-ta586u"
+	labels := mdb.BuildLabel(isArbiter)
+
 	return service.Builder().
 		SetName(name).
 		SetNamespace(mdb.Namespace).
-		SetSelector(label).
-		SetLabels(label).
+		SetSelector(labels).
+		SetLabels(labels).
 		SetServiceType(corev1.ServiceTypeClusterIP).
 		SetClusterIP("None").
 		SetPublishNotReadyAddresses(true).
@@ -874,6 +871,8 @@ func buildArbitersModificationFunction(mdb mdbv1.MongoDBCommunity) statefulset.M
 		statefulset.WithReplicas(mdb.StatefulSetArbitersThisReconciliation()),
 		statefulset.WithServiceName(mdb.ArbiterServiceName()),
 		statefulset.WithName(mdb.Name+"-arb"),
+		statefulset.WithLabels(mdb.BuildLabel(true)),
+		statefulset.WithMatchLabels(mdb.BuildLabel(true)),
 	)
 }
 


### PR DESCRIPTION
labels for statefulset/svc
```
        // m is a mongo cluster instance
	name := m.ServiceName()
	if isArbiter {
		name = m.ArbiterServiceName()
	}

	labels := make(map[string]string)
	labels["app.kubernetes.io/name"] = "mongodb"
	labels["app.kubernetes.io/component"] = "database"
	labels["app.kubernetes.io/instance"] = m.Name
	labels["mongodbcommunity.mongodb.com/app"] = name

	return labels
```
selector for service monitor
```
selector:
    matchLabels:
      app.kubernetes.io/component: database
      app.kubernetes.io/name: mongodb
```
